### PR TITLE
remove console log

### DIFF
--- a/lib/verify.ts
+++ b/lib/verify.ts
@@ -56,7 +56,6 @@ export class JW3TVerifier {
 
     let content = JW3TContent.fromBase64Url(`${b64_header}.${b64_payload}`);
     let jsonStrContent = content.stringify();
-    console.log(jsonStrContent);
     let sigIsValid = await this._sigVerifier.verify(
       algorithm,
       jsonStrContent,


### PR DESCRIPTION
### Description

removes `console.log` in order to keep browser console clean.